### PR TITLE
Add Google Tag Manager

### DIFF
--- a/packages/shop/src/common/gtm/gtm.ts
+++ b/packages/shop/src/common/gtm/gtm.ts
@@ -1,0 +1,1 @@
+export const GTM_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID;

--- a/packages/shop/src/common/gtm/index.ts
+++ b/packages/shop/src/common/gtm/index.ts
@@ -1,0 +1,1 @@
+export * from './gtm';

--- a/packages/shop/src/components/common/google-tag-manager/GoogleTagManager.tsx
+++ b/packages/shop/src/components/common/google-tag-manager/GoogleTagManager.tsx
@@ -1,0 +1,21 @@
+import Script from 'next/script';
+
+type Props = {
+  gtmId: string;
+};
+
+export const GoogleTagManager = ({ gtmId }: Props) => (
+  <Script
+    id="gtag-base"
+    strategy="afterInteractive"
+    dangerouslySetInnerHTML={{
+      __html: `
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer', '${gtmId}');
+          `,
+    }}
+  />
+);

--- a/packages/shop/src/components/common/google-tag-manager/index.tsx
+++ b/packages/shop/src/components/common/google-tag-manager/index.tsx
@@ -1,0 +1,1 @@
+export * from './GoogleTagManager';

--- a/packages/shop/src/pages/_app.page.tsx
+++ b/packages/shop/src/pages/_app.page.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { AppProps } from 'next/app';
-import Script from 'next/script';
 import { ThemeProvider } from 'styled-components/macro';
 // manual importing fontawesome css prevents flashing unstyled fontawesome icon
 // ref: https://github.com/FortAwesome/react-fontawesome/issues/234
@@ -19,6 +18,7 @@ import CSSReset from '@rmp-demo-store/ui/css-reset';
 
 import '../common/i18n';
 import { GTM_ID } from '../common/gtm';
+import { GoogleTagManager } from '../components/common/google-tag-manager';
 
 if (process.env.NODE_ENV !== 'development') {
   // send react-query logs to sentry
@@ -45,22 +45,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
-      {/* Google Tag Manager */}
-      {GTM_ID ? (
-        <Script
-          id="gtag-base"
-          strategy="afterInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `
-            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer', '${GTM_ID}');
-          `,
-          }}
-        />
-      ) : null}
+      {GTM_ID ? <GoogleTagManager gtmId={GTM_ID} /> : null}
       <QueryClientProvider client={queryClient}>
         <Hydrate state={pageProps.dehydratedState}>
           <ThemeProvider theme={theme}>

--- a/packages/shop/src/pages/_app.page.tsx
+++ b/packages/shop/src/pages/_app.page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { AppProps } from 'next/app';
+import Script from 'next/script';
 import { ThemeProvider } from 'styled-components/macro';
 // manual importing fontawesome css prevents flashing unstyled fontawesome icon
 // ref: https://github.com/FortAwesome/react-fontawesome/issues/234
@@ -17,6 +18,7 @@ import GlobalStyle from '@rmp-demo-store/ui/global-style';
 import CSSReset from '@rmp-demo-store/ui/css-reset';
 
 import '../common/i18n';
+import { GTM_ID } from '../common/gtm';
 
 if (process.env.NODE_ENV !== 'development') {
   // send react-query logs to sentry
@@ -42,15 +44,33 @@ function MyApp({ Component, pageProps }: AppProps) {
   });
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <Hydrate state={pageProps.dehydratedState}>
-        <ThemeProvider theme={theme}>
-          <CSSReset />
-          <GlobalStyle baseFontSize={16} />
-          <Component {...pageProps} />
-        </ThemeProvider>
-      </Hydrate>
-    </QueryClientProvider>
+    <>
+      {/* Google Tag Manager */}
+      {GTM_ID ? (
+        <Script
+          id="gtag-base"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer', '${GTM_ID}');
+          `,
+          }}
+        />
+      ) : null}
+      <QueryClientProvider client={queryClient}>
+        <Hydrate state={pageProps.dehydratedState}>
+          <ThemeProvider theme={theme}>
+            <CSSReset />
+            <GlobalStyle baseFontSize={16} />
+            <Component {...pageProps} />
+          </ThemeProvider>
+        </Hydrate>
+      </QueryClientProvider>
+    </>
   );
 }
 export default MyApp;

--- a/packages/shop/src/pages/_document.page.tsx
+++ b/packages/shop/src/pages/_document.page.tsx
@@ -1,5 +1,12 @@
-import Document, { DocumentContext } from 'next/document';
+import Document, {
+  DocumentContext,
+  Html,
+  Head,
+  Main,
+  NextScript,
+} from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
+import { GTM_ID } from '../common/gtm';
 
 // ref: https://github.com/vercel/next.js/tree/master/examples/with-typescript-styled-components
 export default class MyDocument extends Document {
@@ -28,5 +35,27 @@ export default class MyDocument extends Document {
     } finally {
       sheet.seal();
     }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          {GTM_ID ? (
+            <noscript>
+              <iframe
+                src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
+                height="0"
+                width="0"
+                style={{ display: 'none', visibility: 'hidden' }}
+              />
+            </noscript>
+          ) : null}
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
   }
 }

--- a/packages/shop/src/pages/api/logout.page.ts
+++ b/packages/shop/src/pages/api/logout.page.ts
@@ -7,11 +7,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   if (method !== 'POST') return res.status(404).end();
 
-  // delete cookie
-  res.setHeader(
-    'Set-Cookie',
-    `session=deleted; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/;`
-  );
+  // delete cookies
+  res.setHeader('Set-Cookie', [
+    `session=deleted; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/;`,
+    `userId=deleted; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/;`,
+  ]);
 
   res.status(200).end();
 };


### PR DESCRIPTION
- Add Google Tag Manager
  - Reference: Next.js official GTM integration [example](https://github.com/vercel/next.js/tree/canary/examples/with-google-tag-manager) 
- Add `userId` cookie (for GTM to read the current user's ID)